### PR TITLE
Use pip module install for container image

### DIFF
--- a/docker/Dockerfile.rhel7.ovs211
+++ b/docker/Dockerfile.rhel7.ovs211
@@ -1,8 +1,8 @@
-FROM quay.io/fedora/fedora:30-x86_64
+FROM rhel7:latest
 LABEL version=1.0
 LABEL maintainer="Gowrishankar Muthukrishnan <gmuthukr@redhat.com>"
 
-RUN yum install -y openvswitch python3-pip && \
+RUN yum install -y --enablerepo="rhel-7-fast-datapath-rpms" openvswitch2.11 python3-pip && \
     yum clean all
 RUN pip3 install netcontrold
 ENTRYPOINT ["/usr/local/bin/ncd_watch"]

--- a/docker/Dockerfile.rhel7.ovs29
+++ b/docker/Dockerfile.rhel7.ovs29
@@ -1,8 +1,8 @@
-FROM quay.io/fedora/fedora:30-x86_64
+FROM rhel7:latest
 LABEL version=1.0
 LABEL maintainer="Gowrishankar Muthukrishnan <gmuthukr@redhat.com>"
 
-RUN yum install -y openvswitch python3-pip && \
+RUN yum install -y --enablerepo="rhel-7-fast-datapath-rpms" openvswitch python3-pip && \
     yum clean all
 RUN pip3 install netcontrold
 ENTRYPOINT ["/usr/local/bin/ncd_watch"]


### PR DESCRIPTION
pip module has been added for netcontrold, use the pip install, instead of the local rpm install. 

Also created docker files for different ovs versions - 2.9 and 2.11, For OSP it will use the right version when it is built with kolla, but for external users, specific version has to be used as per the deployment.