### PR TITLE
Move log file into a folder

### DIFF
--- a/ncd_watch
+++ b/ncd_watch
@@ -12,5 +12,6 @@ trap "sigterm_cb" TERM
 ncd_ctl start
 
 # monitor log
-tail -f /var/log/ncd.log &
+mkdir -p /var/log/netcontrold
+tail -f /var/log/netcontrold/ncd.log &
 wait


### PR DESCRIPTION
Instead of logging directly on /var/log, move it to a
directory, which will be easy for running it as container
to capture the logs in the host machine.